### PR TITLE
Potential IconsHandler bug fix

### DIFF
--- a/src/com/android/launcher3/icons/IconsHandler.java
+++ b/src/com/android/launcher3/icons/IconsHandler.java
@@ -336,8 +336,9 @@ public class IconsHandler {
             }
         }
 
-        return generateBitmap(Bitmap.createBitmap(drawable.getIntrinsicWidth(),
-                drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888));
+        return generateBitmap((drawable instanceof BitmapDrawable) ?
+                ((BitmapDrawable) drawable).getBitmap() :
+                Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888));
     }
 
     public void switchIconPacks(String packageName) {


### PR DESCRIPTION
Consider case where (drawable instanceof BitmapDrawable) and is using default icon pack to avoid creating an empty icon