### PR TITLE
Change sans-serif-condensed font to sans-serif

### DIFF
--- a/res/layout/user_folder_icon_normalized.xml
+++ b/res/layout/user_folder_icon_normalized.xml
@@ -48,7 +48,7 @@
             android:layout_gravity="center_vertical"
             android:layout_weight="1"
             android:background="@android:color/transparent"
-            android:fontFamily="sans-serif-condensed"
+            android:fontFamily="sans-serif"
             android:textStyle="bold"
             android:gravity="center_horizontal"
             android:hint="@string/folder_hint_text"


### PR DESCRIPTION
No other part of Trebuchet has sans-serif-condensed anymore, sans-serif uses only a bit more space than sans-serif-condensed, so change the folder name font to sans-serif for better UI consistency.